### PR TITLE
Put quotes around $FIREFLY_PATH to prevent install fail

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -155,7 +155,7 @@ php artisan config:cache
 
 # make sure we own everything
 echo "Run chown on ${FIREFLY_PATH}"
-chown -R www-data:www-data -R $FIREFLY_PATH
+chown -R www-data:www-data -R "$FIREFLY_PATH"
 
 php artisan firefly:instructions install
 


### PR DESCRIPTION
Installing Firefly on Centos 7 with Docker using latest image on dockerhub failed to progress past line 158 in entrypoint.sh - surrounding $FIREFLY_PATH with quotes allowed the installation to proceed.

@JC5
