### PR TITLE
Use the arm64 base image for Dockerfile.arm64

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM jc5x/firefly-iii-base-image:latest-arm
+FROM jc5x/firefly-iii-base-image:latest-arm64
 
 # See also: https://github.com/JC5/firefly-iii-base-image
 


### PR DESCRIPTION
Had trouble upgrading my server recently and ended up attempting to build locally when I came across this. Can confirm that the resulting image after this fix works (at least on my server...).

Changes in this pull request:
- Make building and running the arm64 image work

@JC5
