### PR TITLE
Force fetch amd64 variant for amd64 image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM jc5x/firefly-iii-base-image:latest
+FROM jc5x/firefly-iii-base-image:latest-amd64
 
 # See also: https://github.com/JC5/firefly-iii-base-image
 


### PR DESCRIPTION
Changes in this pull request:

- If you would build this image on arm the "amd64" image would arm64 and not amd64.

@JC5
