### PR TITLE
just a first workaround for caching-issues

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -15,6 +15,11 @@ COPY [ "scripts/wait-for-it.sh", "/wait-for-it.sh" ]
 COPY [ "scripts/entrypoint.sh", "/entrypoint.sh" ]
 RUN chmod +x /entrypoint.sh && chmod +x /wait-for-it.sh && mkdir /var/www/firefly-iii && chown -R www-data:www-data /var/www/firefly-iii 
 
+RUN apt -qy update && \
+    apt -qy install sudo && \
+    usermod -a -G sudo www-data && \
+    echo "%sudo ALL=(ALL) NOPASSWD: $( which apache2-foreground )" >> /etc/sudoers.d/ugly-workaround
+
 USER www-data
 
 WORKDIR /var/www/firefly-iii
@@ -26,7 +31,5 @@ RUN curl -SL https://github.com/firefly-iii/firefly-iii/archive/$VERSION.tar.gz 
 
 EXPOSE 80
 VOLUME $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
-
-USER root
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -229,4 +229,4 @@ export IS_DOCKER=true
 php artisan firefly:instructions install
 
 echo "Go!"
-exec apache2-foreground
+exec sudo $( which apache2-foreground )


### PR DESCRIPTION
Fixes issue https://github.com/firefly-iii/firefly-iii/issues/3449

Changes in this pull request:

Dont run php-calls in entrypoint.sh as user root, instead use sudo to start apache as root - which will drop privileges as soon as port is binded.

@JC5
