### PR TITLE
Remove firefly_iii_export volume as it is no longer used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,5 @@ services:
     volumes:
       - firefly_iii_db:/var/lib/mysql
 volumes:
-   firefly_iii_export:
    firefly_iii_upload:
    firefly_iii_db:


### PR DESCRIPTION
Changes in this pull request:

- Since Firefly 5.4.0 the export volume is no longer used. The mounting of the export volume has already been removed from this `docker-compose.yml`, but the volume is still created. This can be removed as it is not used.

@JC5
