### PR TITLE
Allow entrypoint.sh to delete all contents in `/storage/framework/cache/data/*`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -202,7 +202,7 @@ then
       APACHE_RUN_GROUP='www-data'
 fi
 
-rm -f $FIREFLY_III_PATH/storage/framework/cache/data/*
+rm -rf $FIREFLY_III_PATH/storage/framework/cache/data/*
 rm -f $FIREFLY_III_PATH/storage/logs/*.log
 chown -R $APACHE_RUN_USER:$APACHE_RUN_GROUP $FIREFLY_III_PATH/storage
 chmod -R 775 $FIREFLY_III_PATH/storage


### PR DESCRIPTION
Fixes issue https://github.com/firefly-iii/firefly-iii/issues/4059 (if relevant)

Changes in this pull request:

- Modify `entrypoint.sh` to remove not only files but directories in `$FIREFLY_III_PATH/storage/framework/cache/data/*`

@JC5
