### PR TITLE
Fix cronjobs not working

### DIFF
--- a/docker-compose-importer.yml
+++ b/docker-compose-importer.yml
@@ -55,7 +55,7 @@ services:
     image: alpine
     container_name: firefly_iii_cron
     restart: always
-    command: sh -c "echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/REPLACEME\" | crontab - && crond -f -L /dev/stdout"
+    command: sh -c "echo \"0 3 \* \* \* wget -qO- http://app:8080/api/v1/cron/REPLACEME\" | crontab - && crond -f -L /dev/stdout"
     networks:
       - firefly_iii
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     image: alpine
     restart: always
     container_name: firefly_iii_cron
-    command: sh -c "echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/REPLACEME\" | crontab - && crond -f -L /dev/stdout"
+    command: sh -c "echo \"0 3 \* \* \* wget -qO- http://app:8080/api/v1/cron/REPLACEME\" | crontab - && crond -f -L /dev/stdout"
     networks:
       - firefly_iii
 


### PR DESCRIPTION
Problem: Cronjob is filled with directory listing of cronjob rontiners root
```
0 3 bin dev etc home lib media mnt opt proc root run sbin srv sys tmp usr var bin dev etc home lib media mnt opt proc root run sbin srv sys tmp usr var bin dev etc home lib media mnt opt proc root run sbin srv sys tmp usr var wget -qO- http://app:8080/api/v1/cron/REPLACEME
```
Solution: Escape * symbol

@JC5
