### PR TITLE
Make cron container timezone aware

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,13 @@ services:
     image: alpine
     restart: always
     container_name: firefly_iii_cron
-    command: sh -c "echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/REPLACEME;echo\" | crontab - && crond -f -L /dev/stdout"
+    env_file: .env
+    command: sh -c "
+      apk add tzdata
+      && ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
+      | echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/REPLACEME;echo\" 
+      | crontab - 
+      && crond -f -L /dev/stdout"
     networks:
       - firefly_iii
 


### PR DESCRIPTION
The cron container defaults to the UTC timezone making crontab entries and jobs relative to UTC rather than the timezone designated in .env. This change adds the tzdata database to the cron container and sets the timezone to the value set in .env.

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # (if relevant).
[#9565](https://github.com/firefly-iii/firefly-iii/issues/9565)

Changes in this pull request:

- Make cron container timezone aware

@JC5
