### PR TITLE
Docker compose: Changing /storage/upload to /storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: firefly_iii_core
     restart: always
     volumes:
-      - firefly_iii_upload:/var/www/html/storage/upload
+      - firefly_iii_storage:/var/www/html/storage
     env_file: .env
     networks:
       - firefly_iii
@@ -42,7 +42,7 @@ services:
       - firefly_iii
 
 volumes:
-   firefly_iii_upload:
+   firefly_iii_storage:
    firefly_iii_db:
 
 networks:


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #10429.

Changes in this pull request:

- Persistent volume is changed to /var/www/html/storage. This preserves `oauth-private.key` and `oauth-public.key` between container restarts, thus preserving the validity of personal access tokens.
