### PR TITLE
Remove the need to hardcode the STATIC_CRON_TOKEN in the docker compose

### DIFF
--- a/docker-compose-importer.yml
+++ b/docker-compose-importer.yml
@@ -47,7 +47,7 @@ services:
 
   cron:
     #
-    # To make this work, set STATIC_CRON_TOKEN in your .env file or as an environment variable and replace PLEASE_REPLACE_WITH_32_CHAR_CODE below
+    # To make this work, set STATIC_CRON_TOKEN in your .env file or as an environment variable
     # The STATIC_CRON_TOKEN must be *exactly* 32 characters long
     # Use this URL for inspiration: https://www.random.org/strings/?num=1&len=32&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new
     #
@@ -57,7 +57,7 @@ services:
     command: sh -c "
       apk add tzdata
       && ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
-      | echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/PLEASE_REPLACE_WITH_32_CHAR_CODE;echo\" 
+      | echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/$$STATIC_CRON_TOKEN;echo\"
       | crontab - 
       && crond -f -L /dev/stdout"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - firefly_iii_db:/var/lib/mysql
   cron:
     #
-    # To make this work, set STATIC_CRON_TOKEN in your .env file or as an environment variable and replace PLEASE_REPLACE_WITH_32_CHAR_CODE below
+    # To make this work, set STATIC_CRON_TOKEN in your .env file or as an environment variable
     # The STATIC_CRON_TOKEN must be *exactly* 32 characters long
     #
     image: alpine
@@ -35,7 +35,7 @@ services:
     command: sh -c "
       apk add tzdata
       && ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
-      | echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/PLEASE_REPLACE_WITH_32_CHAR_CODE;echo\" 
+      | echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/$$STATIC_CRON_TOKEN;echo\"
       | crontab - 
       && crond -f -L /dev/stdout"
     networks:


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR removes the need to hard code the `STATIC_CRON_TOKEN` value in the docker-compose files, making them free of secrets.

Documentation for the docker-compose feature that makes this change possible is [here](https://docs.docker.com/reference/compose-file/interpolation/).

I've tested it locally but since I'm just now setting up firefly-iii for the first time I may be missing some corner case or exotic use case that I'm not yet aware of.